### PR TITLE
DJAN-44: minor fix for trailing slash in webapp urls

### DIFF
--- a/landing/templates/listApps.html
+++ b/landing/templates/listApps.html
@@ -17,7 +17,7 @@
                 </tr>
                 {% for app in appList %}
                     <tr>
-                        <td><a href="./{{ app }}">{{ app }}</a></td>
+                        <td><a href="{{ base }}/{{ app }}">{{ app }}</a></td>
                     </tr>
                 {% endfor %}
             </table>

--- a/landing/views.py
+++ b/landing/views.py
@@ -28,4 +28,4 @@ def index(request):
         appList = [app for app in appList if not app in loginRequiredApps]
     
     appList.sort()
-    return render(request, 'listApps.html', {'appList': appList, 'labels': 'name file'.split(' '), 'title': TITLE, 'hostname': hostname})
+    return render(request, 'listApps.html', {'appList': appList, 'labels': 'name file'.split(' '), 'title': TITLE, 'hostname': hostname, 'base': settings.WSGI_BASE})


### PR DESCRIPTION
Replicating this fix for bampfa since it works for ucjeps and pahma. 